### PR TITLE
Update bless_client.py to be a little more flexible

### DIFF
--- a/bless/aws_lambda/bless_lambda.py
+++ b/bless/aws_lambda/bless_lambda.py
@@ -105,13 +105,13 @@ def lambda_handler(event, context=None, ca_private_key_password=None,
         context.aws_request_id, request.bastion_user, request.bastion_user_ip, request.command,
         cert_builder.ssh_public_key.fingerprint, context.invoked_function_arn,
         time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(valid_before)))
-    cert_builder.set_critical_option_source_address(request.bastion_ip)
+    cert_builder.set_critical_option_source_address('{},{}'.format(request.bastion_user_ip, request.bastion_ips))
     cert_builder.set_key_id(key_id)
     cert = cert_builder.get_cert_file()
 
     logger.info(
-        'Issued a cert to bastion_ip[{}] for the remote_username of [{}] with the key_id[{}] and '
+        'Issued a cert to bastion_ips[{}] for the remote_username of [{}] with the key_id[{}] and '
         'valid_from[{}])'.format(
-            request.bastion_ip, request.remote_username, key_id,
+            request.bastion_ips, request.remote_username, key_id,
             time.strftime("%Y/%m/%d %H:%M:%S", time.gmtime(valid_after))))
     return cert

--- a/bless/request/bless_request.py
+++ b/bless/request/bless_request.py
@@ -11,9 +11,10 @@ from marshmallow import Schema, fields, post_load, ValidationError
 USERNAME_PATTERN = re.compile('[a-z_][a-z0-9_-]*[$]?\Z')
 
 
-def validate_ip(ip):
+def validate_ips(ips):
     try:
-        ipaddress.ip_address(ip)
+        for ip in ips.split(','):
+            ipaddress.ip_address(ip)
     except ValueError:
         raise ValidationError('Invalid IP address.')
 
@@ -26,9 +27,9 @@ def validate_user(user):
 
 
 class BlessSchema(Schema):
-    bastion_ip = fields.Str(validate=validate_ip)
+    bastion_ips = fields.Str(validate=validate_ips)
     bastion_user = fields.Str(validate=validate_user)
-    bastion_user_ip = fields.Str(validate=validate_ip)
+    bastion_user_ip = fields.Str(validate=validate_ips)
     command = fields.Str()
     public_key_to_sign = fields.Str()
     remote_username = fields.Str(validate=validate_user)
@@ -39,11 +40,11 @@ class BlessSchema(Schema):
 
 
 class BlessRequest:
-    def __init__(self, bastion_ip, bastion_user, bastion_user_ip, command, public_key_to_sign,
+    def __init__(self, bastion_ips, bastion_user, bastion_user_ip, command, public_key_to_sign,
                  remote_username):
         """
         A BlessRequest must have the following key value pairs to be valid.
-        :param bastion_ip: The source IP where the ssh connection will be initiated from.  This is
+        :param bastion_ips: The source IPs where the ssh connection will be initiated from.  This is
         enforced in the issued certificate.
         :param bastion_user: The user on the bastion, who is initiating the ssh request.
         :param bastion_user_ip: The IP of the user accessing the bastion.
@@ -53,7 +54,7 @@ class BlessRequest:
         :param remote_username: The username on the remote server that will be used in the ssh
         request.  This is enforced in the issued certificate.
         """
-        self.bastion_ip = bastion_ip
+        self.bastion_ips = bastion_ips
         self.bastion_user = bastion_user
         self.bastion_user_ip = bastion_user_ip
         self.command = command

--- a/bless_client/bless_client.py
+++ b/bless_client/bless_client.py
@@ -6,7 +6,6 @@ Usage:
   bless_client.py region lambda_function_name bastion_user bastion_user_ip remote_username bastion_source_ip bastion_command <id_rsa.pub to sign> <output id_rsa-cert.pub>
 
 """
-import base64
 import json
 import sys
 
@@ -19,7 +18,8 @@ def main(argv):
             'Usage: bless_client.py region lambda_function_name bastion_user bastion_user_ip remote_username bastion_source_ip bastion_command <id_rsa.pub to sign> <output id_rsa-cert.pub>')
         return -1
 
-    if 'AWS_SECRET_ACCESS_KEY' not in os.environ:
+    credentials_file = os.path.join(os.environ['HOME'], '.aws', 'credentials')
+    if 'AWS_SECRET_ACCESS_KEY' not in os.environ and not os.path.isfile(credentials_file):
         print ('You need AWS credentials in your environment')
         return -1
 
@@ -29,15 +29,15 @@ def main(argv):
         public_key = f.read()
 
     payload = {'bastion_user': argv[2], 'bastion_user_ip': argv[3], 'remote_username': argv[4],
-               'bastion_ip': argv[5],
+               'bastion_ips': argv[5],
                'command': argv[6], 'public_key_to_sign': public_key}
     payload_json = json.dumps(payload)
 
     print('Executing:')
     lambda_client = boto3.client('lambda', region_name=region)
     response = lambda_client.invoke(FunctionName=argv[1], InvocationType='RequestResponse',
-                                    LogType='Tail', Payload=payload_json)
-    print('{}\n\n{}'.format(response['ResponseMetadata'], base64.b64decode(response['LogResult'])))
+                                    LogType='None', Payload=payload_json)
+    print('{}\n\n'.format(response['ResponseMetadata']))
 
     if response['StatusCode'] != 200:
         print ('Error creating cert.')

--- a/tests/aws_lambda/test_bless_lambda.py
+++ b/tests/aws_lambda/test_bless_lambda.py
@@ -15,7 +15,7 @@ VALID_TEST_REQUEST = {
     "remote_username": "user",
     "public_key_to_sign": EXAMPLE_RSA_PUBLIC_KEY,
     "command": "ssh user@server",
-    "bastion_ip": "127.0.0.1",
+    "bastion_ips": "127.0.0.1",
     "bastion_user": "user",
     "bastion_user_ip": "127.0.0.1"
 }
@@ -52,7 +52,7 @@ def test_local_request_invalid_pub_key():
         "remote_username": "user",
         "public_key_to_sign": EXAMPLE_ED25519_PUBLIC_KEY,
         "command": "ssh user@server",
-        "bastion_ip": "127.0.0.1",
+        "bastion_ips": "127.0.0.1",
         "bastion_user": "user",
         "bastion_user_ip": "127.0.0.1"
     }

--- a/tests/request/test_bless_request.py
+++ b/tests/request/test_bless_request.py
@@ -1,12 +1,15 @@
 import pytest
-from bless.request.bless_request import validate_ip, validate_user
+from bless.request.bless_request import validate_ips, validate_user
 from marshmallow import ValidationError
 
 
-def test_validate_ip():
-    validate_ip(u'127.0.0.1')
+def test_validate_ips():
+    validate_ips(u'127.0.0.1')
     with pytest.raises(ValidationError):
-        validate_ip(u'256.0.0.0')
+        validate_ips(u'256.0.0.0')
+    validate_ips(u'127.0.0.1,172.1.1.1')
+    with pytest.raises(ValidationError):
+        validate_ips(u'256.0.0.0,172.1.1.1')
 
 
 def test_validate_user_too_long():
@@ -25,6 +28,7 @@ def test_validate_user_contains_junk(test_input):
     with pytest.raises(ValidationError) as e:
         validate_user(test_input)
     assert e.value.message == 'Username contains invalid characters'
+
 
 @pytest.mark.parametrize("test_input", [
     ('uservalid'),


### PR DESCRIPTION
- Allow bless_client.py to use ~/.aws/credentials.
- Use LogType=None because the logs generally live in another account.
- Support  specification of multiple bastion ips and include the bastion
  ips in the source-address Critical Options
